### PR TITLE
ci(release): adopt unified release pipeline via reusable workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,68 +1,24 @@
-name: Build Docker images
+name: Docker
 
 on:
-  release:
-    types: [published]
   schedule:
     - cron: "0 0 * * 0"
+  pull_request:
   push:
     branches:
+      - main
       - master
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: "${{ github.repository_owner }}/raybeam"
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Cache docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: cache
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Gather Docker metadata
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{version}}.{{major}}
-          labels: |
-            cache-from=type=local,src=/tmp/.buildx-cache
-            cache-to=type=local,dest=/tmp/.buildx-cache
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+  build:
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: raybeam
+      platforms: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,79 @@
-name: Create GitHub release
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)build (e.g. v1.0.9)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
-  release:
+  create-release:
+    name: Create GitHub Release
+    uses: netresearch/.github/.github/workflows/create-release.yml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag || '' }}
+
+  binaries:
+    name: Build binaries
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
-        goos: [linux, darwin]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        include:
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: linux, goarch: arm, goarm: "7" }
+          - { goos: darwin, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
+    uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      binary-name: raybeam-${{ matrix.goos }}-${{ matrix.goarch }}
+      goos: ${{ matrix.goos }}
+      goarch: ${{ matrix.goarch }}
+      goarm: ${{ matrix.goarm || '' }}
+      ref: ${{ needs.create-release.outputs.tag }}
+      release-tag: ${{ needs.create-release.outputs.tag }}
+      sbom: true
 
-      - name: Release binaries
-        uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: amd64
+  container:
+    name: Build container image
+    needs: create-release
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+    with:
+      image-name: raybeam
+      ref: ${{ needs.create-release.outputs.tag }}
+      platforms: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"
+      sign: true
+      attest: true
+
+  finalize:
+    name: Finalize release
+    needs: [create-release, binaries, container]
+    uses: netresearch/.github/.github/workflows/finalize-release.yml@main
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      tag: ${{ needs.create-release.outputs.tag }}
+      image-ref: ghcr.io/${{ github.repository_owner }}/raybeam


### PR DESCRIPTION
## Summary

Adopts the org-wide unified release pipeline (netresearch/.github/.github/workflows/{create-release,build-go-attest,build-container,finalize-release}.yml). Replaces the manual-GitHub-release + \`wangyoucao577/go-release-action\` flow with a fully automated tag-push pipeline.

## What ships on tag push (\`vX.Y.Z\`)

| Artifact | Provenance | SBOM | Signature |
|---|---|---|---|
| \`raybeam-{linux,darwin}-{amd64,arm64}\` | ✅ SLSA L3 | ✅ Syft SPDX | via checksums bundle |
| \`raybeam-linux-arm\` (v7) | ✅ SLSA L3 | ✅ Syft SPDX | via checksums bundle |
| \`ghcr.io/netresearch/raybeam:{X.Y.Z,X.Y,X}\` multi-arch | ✅ SLSA + OCI referrer | — | ✅ cosign keyless OIDC |
| \`checksums.txt\` (+.pem +.sig) | ✅ | — | ✅ |

**Arch expansion:** linux/arm64 + linux/arm7 + darwin/{amd64,arm64} (previously: linux/amd64 + darwin/amd64 only — 5 binaries up from 2).

## Behavior changes

- **Trigger** is tag push (was: manual GitHub release creation). CI does the release creation now.
- **Signed/annotated tags required** (\`git tag -s vX.Y.Z -m "vX.Y.Z"\`).
- **\`make_latest\` computed from semver** — bugfix tags on older majors no longer steal the "Latest" badge.
- **sha256 checksums** (was: md5).
- **Trivy security scanning** on the container image (SARIF → GitHub Security).
- **Backfill:** \`gh workflow run release.yml --ref main -f tag=v1.0.9\`.

## Files

- **Modified** \`.github/workflows/release.yml\` — now orchestrates the 4 reusable workflows.
- **Modified** \`.github/workflows/docker.yml\` — ~60 lines of bespoke build collapsed to a 14-line reusable caller; listens on both \`main\` and \`master\` (default branch was historically master).

## Test plan

- [ ] CI green on this PR (exercises the simplified docker.yml via PR trigger).
- [ ] After merge + signed tag push, release.yml runs and produces all artifacts above.