### PR TITLE
fix(docker): grant id-token/attestations at caller

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,6 +20,8 @@ jobs:
       contents: read
       packages: write
       security-events: write
+      id-token: write
+      attestations: write
     with:
       image-name: raybeam
       platforms: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64"


### PR DESCRIPTION
Follow-up to unified release migration. Grants `id-token: write` + `attestations: write` at the caller job level and adds `workflow_dispatch` trigger.

## Why

The reusable `build-container.yml@main` declares these permissions at workflow-level (for sign/attest features added in netresearch/.github#23). Callers must grant at least the union of reusable-declared permissions, otherwise push-event runs fail at `startup_failure` before any job starts.

Verified with the fix on `netresearch/ldap-selfservice-password-changer` (PR #535, merged as `e234d803`) — post-merge Docker run succeeded on push to main.