### PR TITLE
chore(ci): unpin netresearch/.github reusables back to @main

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   auto-merge:
     name: Auto-merge
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   go-check:
     name: Go
-    uses: netresearch/.github/.github/workflows/go-check.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/go-check.yml@main
     permissions:
       contents: read
       security-events: write
@@ -25,10 +25,10 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint-workflows:
-    uses: netresearch/.github/.github/workflows/lint-workflows.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-workflows.yml@main
 
   lint-markdown:
-    uses: netresearch/.github/.github/workflows/lint-markdown.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-markdown.yml@main
 
   lint-yaml:
-    uses: netresearch/.github/.github/workflows/lint-yaml.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/lint-yaml.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (Go)
-    uses: netresearch/.github/.github/workflows/codeql.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   quality:
     name: Quality
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   create-release:
     name: Create GitHub Release
-    uses: netresearch/.github/.github/workflows/create-release.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/create-release.yml@main
     permissions:
       contents: write
     with:
@@ -35,7 +35,7 @@ jobs:
           - { goos: linux, goarch: arm, goarm: "7" }
           - { goos: darwin, goarch: amd64 }
           - { goos: darwin, goarch: arm64 }
-    uses: netresearch/.github/.github/workflows/build-go-attest.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
     permissions:
       contents: write
       id-token: write
@@ -52,7 +52,7 @@ jobs:
   container:
     name: Build container image
     needs: create-release
-    uses: netresearch/.github/.github/workflows/build-container.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/build-container.yml@main
     permissions:
       contents: read
       packages: write
@@ -69,7 +69,7 @@ jobs:
   finalize:
     name: Finalize release
     needs: [create-release, binaries, container]
-    uses: netresearch/.github/.github/workflows/finalize-release.yml@4f6d149347c61a27ce243f5ac8011d6748487341 # main
+    uses: netresearch/.github/.github/workflows/finalize-release.yml@main
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
The earlier SHA-pin commit treated org-internal reusables like third-party actions. It shouldn't have.

**Pinning \`actions/checkout@<sha>\`**: correct. Upstream is outside our trust boundary; a maintainer-key compromise is a real threat; SHA = immutable guarantee.

**Pinning \`netresearch/.github/...@<sha>\`**: security theater in our setup.

- Same trust boundary — anyone who could force-push the reusables repo already owns the caller repos.
- Reintroduces the duplication the migration just eliminated: every reusable change needs a Renovate PR in every caller.
- Delays security fixes by the Renovate cycle instead of applying immediately.
- \`netresearch/.github:main\` has its own branch protection and CI gates — attacking it is the same bar as attacking any other main branch in the org.

This reverts the internal refs to \`@main\`. External-action SHA pins (\`actions/*\`, \`oven-sh/*\`, \`step-security/*\`, etc.) are **kept** — that's where pinning is actually meaningful.