### PR TITLE
fix(.gitignore): anchor /raybeam to avoid shadowing source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.db
-raybeam
+/raybeam


### PR DESCRIPTION
Fleet-wide .gitignore hardening. Bare `raybeam` matches any file or directory of that name anywhere in the tree; anchor with `/` so only the repo-root binary is ignored. Pre-emptive fix for the same class of bug that hit ldap-manager's cmd/ldap-manager/main_test.go earlier.