### PR TITLE
fix(main): forward release ldflags into internal/build.Version

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,27 @@
 package main
 
-import "raybeam/cmd"
+import (
+	"raybeam/cmd"
+	buildpkg "raybeam/internal/build"
+)
+
+// Build-injected version metadata. Populated by release.yml's ldflags
+// (`-X main.version=<tag>`, `-X main.build=<commit-sha>`); forwarded
+// into internal/build at init() so `raybeam --version` reports the
+// release tag on tagged releases. Empty on `go run` / untagged
+// builds, in which case internal/build falls back to ReadBuildInfo's
+// vcs.revision as before.
+var (
+	version = ""
+	build   = ""
+)
+
+func init() {
+	if version != "" {
+		buildpkg.Version = version
+	}
+	_ = build // reserved — ldflag target, not currently consumed.
+}
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary

Copilot-review follow-up from [#219](https://github.com/netresearch/raybeam/pull/219) / [#220](https://github.com/netresearch/raybeam/pull/220): the template's release ldflags (`-X main.version=<tag>`, `-X main.build=<commit>`) targeted variables that didn't exist in raybeam's main package, so tagged releases still reported the default `Version = vcs.revision` (commit SHA only).

Add `var version, build string` to `main.go` (alias `internal/build` as `buildpkg` to avoid shadowing), and forward the injected value into `buildpkg.Version` at `init()`. Tagged releases now show the tag via cobra's `--version` flag; untagged builds keep falling back to `ReadBuildInfo`'s `vcs.revision` via the original closure in `internal/build/build.go` — unchanged.

## Test plan

- [x] `go build ./...` + `go vet` pass.
- [ ] Next tagged release: `raybeam --version` prints `raybeam version <tag>` instead of `<commit-sha>`.