### PR TITLE
fix(cmd): defer cobra.Command.Version until Execute()

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,13 +8,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// rootCmd's Version is assigned at Execute() time rather than at the
+// var declaration so that package main's init() has a chance to forward
+// the release ldflag into build.Version first. Go initializes imported
+// packages before the importer, so cmd.init() runs before main.init();
+// capturing build.Version here would freeze it at the pre-ldflag value.
 var rootCmd = &cobra.Command{
-	Use:     "raybeam",
-	Short:   "A simple public key store, currently supporting only SSH keys",
-	Version: build.Version,
+	Use:   "raybeam",
+	Short: "A simple public key store, currently supporting only SSH keys",
 }
 
 func Execute() {
+	rootCmd.Version = build.Version
 	if err := rootCmd.Execute(); err != nil {
 		// Ignore errors that occur by printing to stderr, because where are we going to print them
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
Copilot review on [#222](https://github.com/netresearch/raybeam/pull/222): Go initializes the `cmd` package BEFORE package main's init runs, so the previous `Version: build.Version` captured the pre-ldflag value (ReadBuildInfo's `vcs.revision`) and main.init's forward into `build.Version` never reached rootCmd.

Drop the Version field from the var declaration and assign it inside `Execute()`, which runs after all inits. Now `raybeam --version` reports the release tag on tagged releases, as intended.