### PR TITLE
feat(version): surface commit SHA in cobra --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,17 @@ jobs:
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
       goarm: ${{ matrix.goarm || '' }}
-      ldflags: "-s -w -X main.version=${{ needs.create-release.outputs.tag }} -X main.build=${{ needs.create-release.outputs.sha }}"
+      # Fleet ldflag convention: repos that want to surface release
+      # metadata declare `var version, build, buildTime string` in their
+      # main package. Each repo decides which to forward into its own
+      # version package (ofelia uses main.* directly; ldap-manager
+      # forwards into internal/version.*). Empty values are a silent
+      # no-op for repos that don't declare the corresponding var.
+      ldflags: >-
+        -s -w
+        -X main.version=${{ needs.create-release.outputs.tag }}
+        -X main.build=${{ needs.create-release.outputs.sha }}
+        -X main.buildTime=${{ github.event.head_commit.timestamp }}
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,10 +19,32 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	rootCmd.Version = build.Version
+	rootCmd.Version = formatVersion(build.Version, build.CommitHash)
 	if err := rootCmd.Execute(); err != nil {
 		// Ignore errors that occur by printing to stderr, because where are we going to print them
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// formatVersion assembles cobra's Version string from build.Version
+// (release tag) and build.CommitHash (git SHA). Layout:
+//
+//	<version>                           - commit unset (local go run)
+//	<version> (<commit-short>)          - both set (tagged release, or
+//	                                      untagged build where Version
+//	                                      equals the SHA — dedup)
+//
+// Extracted for unit-testability.
+func formatVersion(version, commit string) string {
+	if commit == "" || commit == version {
+		return version
+	}
+
+	short := commit
+	if len(short) > 7 {
+		short = short[:7]
+	}
+
+	return version + " (" + short + ")"
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import "testing"
+
+func TestFormatVersion(t *testing.T) {
+	cases := []struct {
+		name           string
+		version, commit string
+		want           string
+	}{
+		{
+			name:    "version only (no commit)",
+			version: "v1.2.3",
+			commit:  "",
+			want:    "v1.2.3",
+		},
+		{
+			name:    "version + full commit — commit shortened",
+			version: "v1.2.3",
+			commit:  "abcdef1234567890",
+			want:    "v1.2.3 (abcdef1)",
+		},
+		{
+			name:    "version + short commit — kept as-is",
+			version: "v1.2.3",
+			commit:  "abc123",
+			want:    "v1.2.3 (abc123)",
+		},
+		{
+			name:    "dedupe when version == commit (untagged vcs fallback)",
+			version: "abcdef1234567890",
+			commit:  "abcdef1234567890",
+			want:    "abcdef1234567890",
+		},
+		{
+			name:    "unknown version with no commit",
+			version: "unknown",
+			commit:  "",
+			want:    "unknown",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatVersion(tc.version, tc.commit); got != tc.want {
+				t.Errorf("formatVersion(%q, %q) = %q, want %q", tc.version, tc.commit, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -6,7 +6,22 @@ import (
 
 const Repository = "https://github.com/netresearch/raybeam"
 
-var Version = func() string {
+// Version is the release tag or VCS-derived commit SHA. Populated by
+// main.init via ldflags on tagged releases; falls back to
+// ReadBuildInfo's vcs.revision for untagged builds.
+var Version = vcsRevisionOr("unknown")
+
+// CommitHash is the git SHA the binary was built from. Populated by
+// main.init via ldflags (release-time) or set from ReadBuildInfo's
+// vcs.revision at package init.
+var CommitHash = vcsRevisionOr("")
+
+// vcsRevisionOr returns the vcs.revision recorded in the build info,
+// falling back to the provided default when ReadBuildInfo has no
+// VCS settings (e.g. CGO-free static builds in contexts that strip
+// them). Used as the initializer for both Version and CommitHash so
+// the module is fully self-describing without ldflags.
+func vcsRevisionOr(fallback string) string {
 	if info, hasInfo := debug.ReadBuildInfo(); hasInfo {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
@@ -15,5 +30,5 @@ var Version = func() string {
 		}
 	}
 
-	return "unknown"
-}()
+	return fallback
+}

--- a/main.go
+++ b/main.go
@@ -5,22 +5,34 @@ import (
 	buildpkg "raybeam/internal/build"
 )
 
-// Build-injected version metadata. Populated by release.yml's ldflags
-// (`-X main.version=<tag>`, `-X main.build=<commit-sha>`); forwarded
-// into internal/build at init() so `raybeam --version` reports the
-// release tag on tagged releases. Empty on `go run` / untagged
-// builds, in which case internal/build falls back to ReadBuildInfo's
-// vcs.revision as before.
+// Build-injected version metadata. Populated by release.yml's ldflags:
+//
+//	-X main.version=<release-tag>
+//	-X main.build=<commit-sha>
+//
+// Forwarded into internal/build at init() so `raybeam --version`
+// reports release info. Empty on `go run` / untagged builds, in which
+// case internal/build falls back to ReadBuildInfo's vcs.revision.
 var (
 	version = ""
 	build   = ""
 )
 
-func init() {
-	if version != "" {
-		buildpkg.Version = version
+// forwardBuildMetadata copies the build-injected package-main vars
+// into the internal/build package. Extracted from init() for direct
+// unit-testability. Empty inputs are treated as "not injected" and
+// leave the existing buildpkg defaults in place.
+func forwardBuildMetadata(v, b string) {
+	if v != "" {
+		buildpkg.Version = v
 	}
-	_ = build // reserved — ldflag target, not currently consumed.
+	if b != "" {
+		buildpkg.CommitHash = b
+	}
+}
+
+func init() {
+	forwardBuildMetadata(version, build)
 }
 
 func main() {


### PR DESCRIPTION
## Summary

Copilot-review follow-up on [#222](https://github.com/netresearch/raybeam/pull/222): the `build` shim var in main.go was reserved for the `-X main.build` ldflag target but never actually surfaced. Also makes `internal/build` expose CommitHash symmetrically to Version.

### Changes

- **internal/build**: add `CommitHash` var, factor the ReadBuildInfo lookup into `vcsRevisionOr()` for reuse. Both Version and CommitHash self-describe from VCS when ldflags aren't applied.
- **main.go**: extract `forwardBuildMetadata(v, b)` from init() so forwarding is unit-testable; forward the previously-dead `build` var into `buildpkg.CommitHash`.
- **cmd/root.go**: assemble `rootCmd.Version` via `formatVersion()`, which renders `<tag> (<short-commit>)` and dedupes when Version equals CommitHash (the local VCS-fallback case).
- **cmd/root_test.go**: 5 test cases covering tagged / untagged / short-commit / dedupe / unknown paths.
- **release.yml** sync to template revision [netresearch/.github#74](https://github.com/netresearch/.github/pull/74) (adds `main.buildTime` ldflag — silent no-op here since raybeam has no BuildTimestamp consumer, but keeps the file byte-identical with the fleet).

## Test plan

- [x] `go test -v ./cmd` — 5 subtests pass.
- [x] `go build ./...` — OK.