### PR TITLE
chore(build): cache VCS revision + declare buildTime + fix comment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,10 +30,11 @@ func Execute() {
 // formatVersion assembles cobra's Version string from build.Version
 // (release tag) and build.CommitHash (git SHA). Layout:
 //
-//	<version>                           - commit unset (local go run)
-//	<version> (<commit-short>)          - both set (tagged release, or
-//	                                      untagged build where Version
-//	                                      equals the SHA — dedup)
+//	<version>                  - commit unset (local go run) OR
+//	                             commit == version (VCS fallback,
+//	                             no ldflag tag — dedup)
+//	<version> (<commit-short>) - commit set and distinct from version
+//	                             (tagged release)
 //
 // Extracted for unit-testability.
 func formatVersion(version, commit string) string {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -9,26 +9,32 @@ const Repository = "https://github.com/netresearch/raybeam"
 // Version is the release tag or VCS-derived commit SHA. Populated by
 // main.init via ldflags on tagged releases; falls back to
 // ReadBuildInfo's vcs.revision for untagged builds.
-var Version = vcsRevisionOr("unknown")
+var Version = func() string {
+	if vcsRevision != "" {
+		return vcsRevision
+	}
+
+	return "unknown"
+}()
 
 // CommitHash is the git SHA the binary was built from. Populated by
 // main.init via ldflags (release-time) or set from ReadBuildInfo's
 // vcs.revision at package init.
-var CommitHash = vcsRevisionOr("")
+var CommitHash = vcsRevision
 
-// vcsRevisionOr returns the vcs.revision recorded in the build info,
-// falling back to the provided default when ReadBuildInfo has no
-// VCS settings (e.g. CGO-free static builds in contexts that strip
-// them). Used as the initializer for both Version and CommitHash so
-// the module is fully self-describing without ldflags.
-func vcsRevisionOr(fallback string) string {
-	if info, hasInfo := debug.ReadBuildInfo(); hasInfo {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				return setting.Value
-			}
+// vcsRevision is the VCS revision reported by runtime/debug once at
+// package init. Both Version and CommitHash key off it so we only
+// scan build.Settings once.
+var vcsRevision = func() string {
+	info, hasInfo := debug.ReadBuildInfo()
+	if !hasInfo {
+		return ""
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
 		}
 	}
 
-	return fallback
-}
+	return ""
+}()

--- a/main.go
+++ b/main.go
@@ -9,30 +9,39 @@ import (
 //
 //	-X main.version=<release-tag>
 //	-X main.build=<commit-sha>
+//	-X main.buildTime=<commit-timestamp>
 //
 // Forwarded into internal/build at init() so `raybeam --version`
 // reports release info. Empty on `go run` / untagged builds, in which
 // case internal/build falls back to ReadBuildInfo's vcs.revision.
+//
+// buildTime is declared to receive the template's third ldflag target
+// even though raybeam doesn't currently surface a timestamp. Keeping
+// the var declared is cheap insurance against any future linker
+// strictness about unknown -X targets.
 var (
-	version = ""
-	build   = ""
+	version   = ""
+	build     = ""
+	buildTime = ""
 )
 
 // forwardBuildMetadata copies the build-injected package-main vars
 // into the internal/build package. Extracted from init() for direct
 // unit-testability. Empty inputs are treated as "not injected" and
-// leave the existing buildpkg defaults in place.
-func forwardBuildMetadata(v, b string) {
+// leave the existing buildpkg defaults in place. buildTime is
+// accepted but not currently surfaced in cobra's --version output.
+func forwardBuildMetadata(v, b, t string) {
 	if v != "" {
 		buildpkg.Version = v
 	}
 	if b != "" {
 		buildpkg.CommitHash = b
 	}
+	_ = t // reserved for future use; declared so the ldflag has a target.
 }
 
 func init() {
-	forwardBuildMetadata(version, build)
+	forwardBuildMetadata(version, build, buildTime)
 }
 
 func main() {


### PR DESCRIPTION
Follow-ups from copilot review on [#224](https://github.com/netresearch/raybeam/pull/224):

- **`internal/build`**: cache `runtime/debug.ReadBuildInfo`'s `vcs.revision` once in an unexported var, then derive `Version` and `CommitHash` from it. Previously `vcsRevisionOr()` walked `BuildInfo.Settings` twice at package init.
- **`main.go`**: declare `var buildTime string` and take it in `forwardBuildMetadata(v, b, t)` so the template's `-X main.buildTime=...` ldflag has a real target. Stored in `_ = t` because raybeam doesn't surface a timestamp yet — cheap insurance in case of future linker strictness about unknown `-X` targets (current Go silently ignores them, but the fleet now ships all three).
- **`cmd/root.go`**: fix the `formatVersion` doc comment — `(commit-short)` is only appended when commit is set AND != version. Dedupe case is now described correctly.

## Test plan

- [x] `go build ./...` OK.
- [x] `go test ./...` OK (no regression in existing 5 formatVersion cases).