### PR TITLE
docs(build): fix comment reference — debug.BuildInfo.Settings

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -24,7 +24,7 @@ var CommitHash = vcsRevision
 
 // vcsRevision is the VCS revision reported by runtime/debug once at
 // package init. Both Version and CommitHash key off it so we only
-// scan build.Settings once.
+// scan debug.BuildInfo.Settings once.
 var vcsRevision = func() string {
 	info, hasInfo := debug.ReadBuildInfo()
 	if !hasInfo {


### PR DESCRIPTION
Copilot on [#225](https://github.com/netresearch/raybeam/pull/225): comment said 'scan build.Settings once' which reads like a local package symbol (`build` is this package's name). Code actually iterates `debug.BuildInfo.Settings` from `ReadBuildInfo`. Fix the wording.