### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   scorecard:


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.