### PR TITLE
chore(docs): drop the sunset Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![managed by netresearch/.github templates](https://img.shields.io/badge/template-netresearch%2F.github-2F99A4?logo=github)](https://github.com/netresearch/.github/tree/main/templates/go-app)
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/netresearch/raybeam.svg)](https://pkg.go.dev/github.com/netresearch/raybeam)
-[![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/raybeam)](https://goreportcard.com/report/github.com/netresearch/raybeam)
 [![CI Status](https://github.com/netresearch/raybeam/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/raybeam/actions/workflows/ci.yml)
 [![Docker Build](https://github.com/netresearch/raybeam/actions/workflows/docker.yml/badge.svg)](https://github.com/netresearch/raybeam/actions/workflows/docker.yml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/raybeam)](https://go.dev/dl/)


### PR DESCRIPTION
Go Report Card has been sunset — goreportcard.com now serves a farewell page:

> After more than a decade of serving the ecosystem, Go Report Card has been sunset.

The badge therefore renders against a dead service and its link leads nowhere useful. Removing it.

Only the badge lines are touched; no other README content changes. Linting coverage is unaffected — `golangci-lint` runs in CI and is what the badge was a proxy for anyway.
