### PR TITLE
fix: keep test scaffolding out of the binary and bump the toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module raybeam
 
-go 1.25.1
+go 1.26
+
+toolchain go1.26.5
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.14

--- a/internal/server/ldap_client.go
+++ b/internal/server/ldap_client.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	ldap "github.com/netresearch/simple-ldap-go"
+)
+
+// LDAPClient interface defines the LDAP operations needed by the server.
+// This interface allows for mock implementations in tests.
+type LDAPClient interface {
+	FindUserBySAMAccountName(sAMAccountName string) (*ldap.User, error)
+	FindUsersBySAMAccountNames(sAMAccountNames []string) ([]*ldap.User, error)
+	CheckPasswordForSAMAccountName(sAMAccountName, password string) (*ldap.User, error)
+}

--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -11,14 +11,6 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-// LDAPClient interface defines the LDAP operations needed by the server.
-// This interface allows for mock implementations in tests.
-type LDAPClient interface {
-	FindUserBySAMAccountName(sAMAccountName string) (*ldap.User, error)
-	FindUsersBySAMAccountNames(sAMAccountNames []string) ([]*ldap.User, error)
-	CheckPasswordForSAMAccountName(sAMAccountName, password string) (*ldap.User, error)
-}
-
 // MockLDAP implements LDAPClient for testing.
 type MockLDAP struct {
 	users    map[string]*ldap.User
@@ -26,6 +18,11 @@ type MockLDAP struct {
 }
 
 // setObjectDN uses reflection to set the DN field in an ldap.Object (which has unexported fields).
+//
+// simple-ldap-go exposes no constructor that takes a DN — Object.dn is written
+// only by objectFromEntry when decoding a directory response — so a fixture
+// cannot be built through the public API. This lives in a _test.go file so the
+// unsafe write is compiled into the test binary only.
 func setObjectDN(obj interface{}, dn string) {
 	// Get the reflect.Value of the object
 	v := reflect.ValueOf(obj).Elem()


### PR DESCRIPTION
gosec became blocking in the shared workflow ([netresearch/.github#312](https://github.com/netresearch/.github/pull/312)) and immediately failed here, as did govulncheck. Both are fixed.

## gosec: test scaffolding was in the production binary

G103 (*audit unsafe*) pointed at `internal/server/test_helpers.go`. The file has no `_test` suffix, so it compiled into `package server` — the mock LDAP client, the fixture builder, and its `reflect`+`unsafe` write to `ldap.Object`'s unexported `dn` field all shipped in the binary. Nothing called them, but they were there.

Split by what production actually needs: `LDAPClient` is the only declaration used outside tests (2 call sites) and moves to `ldap_client.go`; `MockLDAP`, `NewMockLDAP`, `setObjectDN` and `newTestServer` move to `test_helpers_test.go`. `unsafe` and `reflect` are now compiled into the test binary only.

**No suppression comment.** gosec runs without `-tests`, so the finding is gone because the code left the build — not because it was silenced. A `#nosec` there would have suppressed nothing while implying it had.

The unsafe write itself is unchanged and still justified: simple-ldap-go writes `Object.dn` only in `objectFromEntry` when decoding a directory response and exposes no constructor taking a DN, so a fixture cannot be built through its public API. That library gap is worth closing separately; it is not this PR's job.

## govulncheck: four stdlib advisories

GO-2026-5856 (crypto/tls), GO-2026-5039 (net/textproto), GO-2026-5037 (crypto/x509), GO-2026-4971 (net). The module was on `go 1.25.1` with no `toolchain`. It now uses `go 1.26` with `toolchain go1.26.5`, matching ofelia.

## Verification

Run with go1.26.5:

- gosec: `Issues : 0`, exit 0
- govulncheck: `Your code is affected by 0 vulnerabilities`, exit 0
- `go vet ./...` clean, `go test ./...` passes
- `grep '"unsafe"'` over non-test files returns nothing
