### PR TITLE
docs: fix build references stale since the container-build rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/netresearch/raybeam.svg)](https://pkg.go.dev/github.com/netresearch/raybeam)
 [![CI Status](https://github.com/netresearch/raybeam/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/raybeam/actions/workflows/ci.yml)
-[![Docker Build](https://github.com/netresearch/raybeam/actions/workflows/docker.yml/badge.svg)](https://github.com/netresearch/raybeam/actions/workflows/docker.yml)
+[![Release](https://github.com/netresearch/raybeam/actions/workflows/release.yml/badge.svg)](https://github.com/netresearch/raybeam/actions/workflows/release.yml)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/raybeam)](https://go.dev/dl/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Latest Release](https://img.shields.io/github/v/release/netresearch/raybeam)](https://github.com/netresearch/raybeam/releases)

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,8 +111,8 @@ raybeam/
 ├── README.md                  # Project overview
 ├── LICENSE                    # MIT license
 └── .github/workflows/         # GitHub Actions CI/CD
-    ├── docker.yml             # Docker image builds
-    └── release.yml            # Binary releases
+    ├── ci.yml                 # Lint, test, coverage
+    └── release.yml            # Binaries + container image
 ```
 
 ### Package Organization
@@ -607,31 +607,38 @@ go mod tidy
 
 ### GitHub Actions Workflows
 
-**Docker Build** (`.github/workflows/docker.yml`):
-- Triggers: release publish, weekly cron, master push
-- Builds multi-platform images (linux/amd64, arm64, etc.)
-- Pushes to ghcr.io
+**CI** (`.github/workflows/ci.yml`):
+- Triggers: push to `main`, tags, pull requests, merge queue, weekly cron
+- Lint, unit/integration/e2e tests, fuzzing, license check, coverage
 
 **Release** (`.github/workflows/release.yml`):
-- Triggers: release publish
-- Builds binaries for linux and darwin (amd64)
-- Attaches to GitHub release
+- Triggers: `v*` tag push, manual dispatch
+- Builds binaries for linux (386, amd64, arm64, armv6, armv7), darwin (amd64, arm64) and windows (amd64)
+- Builds the multi-platform container image from those binaries and pushes it to ghcr.io
+- Attaches binaries, SBOMs and attestations to the GitHub release
 
 ### Local Testing
 
-Simulate CI locally:
+The Dockerfile does not compile Go. Its `binary-selector` stage copies a
+pre-built binary from `bin/` and picks the one matching the target platform.
+In CI the release pipeline puts the binaries there; locally you cross-compile
+them yourself first:
 
 ```bash
-# Build Docker image
+# Build the binary for the platform the image should target
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o bin/raybeam-linux-amd64 .
+
+# Build the image
 docker build -t raybeam:test .
 
 # Run container
 docker run --rm raybeam:test raybeam --version
-
-# Test multi-stage build
-docker build --target builder -t raybeam:builder .
-docker build --target runner -t raybeam:runner .
 ```
+
+A multi-platform build needs one binary per target platform in `bin/`: the
+selector maps `linux/386`, `linux/amd64`, `linux/arm64`, `linux/arm/v6` and
+`linux/arm/v7` to `raybeam-linux-386`, `-amd64`, `-arm64`, `-armv6` and
+`-armv7` respectively.
 
 ## Debugging
 


### PR DESCRIPTION
PR #219 rebuilt the container build: the Dockerfile no longer compiles Go — its `binary-selector` stage copies pre-built binaries via `COPY bin/raybeam-linux-* /tmp/`, and `.github/workflows/docker.yml` was deleted. README and `docs/development.md` still described the old world.

**README.md:8** — badge "Docker Build" pointed at `actions/workflows/docker.yml`, a file that no longer exists (dead badge). Now a "Release" badge pointing at `release.yml`. Re-pointed rather than removed because the container image build is a real job in `release.yml`, so a status badge for it still carries information; the existing "Latest Release" badge shows the version, not whether the last run was green. There is no dedicated container workflow to point at — `.github/workflows/` holds `ci.yml` and `release.yml`, no `container.yml`.

**docs/development.md:114** — the repo tree listed `docker.yml # Docker image builds`. Now `ci.yml # Lint, test, coverage`; the `release.yml` comment changed from "Binary releases" to "Binaries + container image".

**docs/development.md:610-618** — the "GitHub Actions Workflows" section documented a **Docker Build** workflow (triggers: release publish, weekly cron, master push) that is gone, and a **Release** entry that was wrong on all three points (trigger is a `v*` tag push, not release publish; binaries cover linux 386/amd64/arm64/armv6/armv7, darwin amd64/arm64 and windows amd64, not "linux and darwin (amd64)"). Replaced by an accurate **CI** entry and a **Release** entry that also covers the container image and the SBOM/attestation assets. Facts read from `release.yml` and the `netresearch/.github` `release-go-app.yml` orchestrator it delegates to.

**docs/development.md:626** — `docker build -t raybeam:test .` was documented as a local build. In a fresh checkout it fails: `ERROR: failed to build: failed to solve: lstat /bin: no such file or directory` (the `COPY bin/raybeam-linux-*` has nothing to copy). The block now cross-compiles first.

**docs/development.md:632-633** (not in the original report) — `docker build --target builder` and `--target runner` were documented as "test multi-stage build". Both stages were removed by #219; each fails with `target stage "builder"/"runner" could not be found` (the runtime stage is unnamed now). Dropped, and replaced with a note on which binary name each platform maps to for a multi-platform build.

Every command in the new block was executed in a clean worktree, in the order documented, and all three succeed: `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o bin/raybeam-linux-amd64 .`, then `docker build -t raybeam:test .`, then `docker run --rm raybeam:test raybeam --version` → `raybeam version unknown` (expected: the release pipeline injects the version via ldflags). The multi-platform mapping sentence is read off the Dockerfile's `case` statement and is not a runnable command, so it was not executed; a buildx multi-arch run was not attempted.

Not touched, but worth a follow-up: the Dockerfile's own header comment (lines 3-4) says the container job "downloads them back into bin/ via `gh release download`". It does not — `release-go-app.yml`'s container job uses `actions/download-artifact` with `pattern: binary-linux-*`.
