### PR TITLE
feat(docker): HEALTHCHECK against /info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,11 @@ COPY --from=binary-selector /usr/bin/raybeam /bin/raybeam
 # CMD (not ENTRYPOINT) preserves the override semantics the previous
 # Dockerfile shipped with — `docker run <image> sh` runs a shell, not
 # `raybeam sh`. Users relying on CMD-override behavior keep working.
+# The serve port is not EXPOSEd/configured here; deployments pass it via the
+# serve flags. 8080 is the documented default and what every known deployment
+# uses (traefik server.port label). Probe /info: cheap, unauthenticated, and
+# proves the HTTP stack + config load, not just the process.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/info || exit 1
+
 CMD ["/bin/raybeam"]


### PR DESCRIPTION
Ops finding from the 2026-W33 maintenance QA (NRT-4584, internal): `docker ps` shows no health state for raybeam — the image defines no HEALTHCHECK, so post-deploy verification falls back to uptime and restart counts, while sibling services (ldap-manager, node-red) report `(healthy)` from their image-level checks.

Alpine base ships busybox `wget`; `/info` is unauthenticated, cheap, and proves the HTTP stack + config load. Port 8080 is the documented serve default used by every known deployment.

Verified against the running 1.1.0 container that `wget -q -O /dev/null http://127.0.0.1:8080/info` succeeds in-container.